### PR TITLE
chore: rename package to @surething/cockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,22 @@ A unified development cockpit built on **Claude Code (Agent SDK)** — chat, cod
 - Chrome extension (Manifest V3) for browser automation bridge
 - CLI tools: `cock browser` / `cock terminal` for headless automation
 
-## Quick Start
+## Install
 
 ```bash
-npm install
-npm run setup       # Build + npm link (registers `cock` command)
+npm install -g @surething/cockpit
 cock                # Start server → http://localhost:3457
 cock -h             # Show help
 cock -v             # Show version
+```
+
+### From Source
+
+```bash
+git clone https://github.com/Surething-io/cockpit.git
+cd cockpit
+npm install
+npm run setup       # Build + npm link (registers `cock` command)
 ```
 
 ## CLI

--- a/README.zh.md
+++ b/README.zh.md
@@ -59,14 +59,22 @@
 - Chrome 插件 (Manifest V3) 浏览器自动化桥接
 - CLI 工具：`cock browser` / `cock terminal` 无头自动化
 
-## 快速开始
+## 安装
 
 ```bash
-npm install
-npm run setup       # 构建 + npm link（注册 cock 命令）
+npm install -g @surething/cockpit
 cock                # 启动服务 → http://localhost:3457
 cock -h             # 查看帮助
 cock -v             # 查看版本
+```
+
+### 从源码安装
+
+```bash
+git clone https://github.com/Surething-io/cockpit.git
+cd cockpit
+npm install
+npm run setup       # 构建 + npm link（注册 cock 命令）
 ```
 
 ## CLI

--- a/bin/cock.mjs
+++ b/bin/cock.mjs
@@ -19,6 +19,7 @@ Commands:
   (default)                    Start Cockpit server (port 3457)
   browser <id> <action>        Control browser bubbles
   terminal <id> <action>       Control terminal bubbles
+  update                       Update to latest version
 
 Options:
   --port <port>                Set server port (default: 3457)
@@ -69,6 +70,17 @@ if (process.argv[2] === 'terminal') {
   const mod = await import('./cock-terminal.mjs');
   await mod.done;
   process.exit(0);
+}
+
+if (process.argv[2] === 'update') {
+  console.log('Updating @surething/cockpit...');
+  const result = spawnSync('npm', ['install', '-g', '@surething/cockpit@latest'], { stdio: 'inherit' });
+  if (result.status === 0) {
+    const { readFileSync } = await import('fs');
+    const pkg = JSON.parse(readFileSync(resolve(PROJECT_ROOT, 'package.json'), 'utf8'));
+    console.log(`\nUpdated to v${pkg.version}`);
+  }
+  process.exit(result.status ?? 1);
 }
 
 // Start (foreground, Ctrl+C to stop)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cockpit",
-  "version": "1.0.169",
+  "version": "1.0.170",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cockpit",
-      "version": "1.0.169",
+      "version": "1.0.170",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@surething/cockpit",
-  "version": "1.0.169",
+  "version": "1.0.170",
   "description": "The Cockpit That Drives AI",
   "author": "Robert",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cockpit",
+  "name": "@surething/cockpit",
   "version": "1.0.169",
   "description": "The Cockpit That Drives AI",
   "author": "Robert",


### PR DESCRIPTION
## Summary
- Rename npm package from `cockpit` (taken) to `@surething/cockpit`

## After merge
Delete old `v1.0.169` tag and re-tag to trigger publish:
```bash
git push origin :refs/tags/v1.0.169
git tag -d v1.0.169 && git tag v1.0.169 && git push origin v1.0.169
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)